### PR TITLE
GP-9257 Fix parameter mismatch in report notification

### DIFF
--- a/Civi/Adyen/Notification/Report.php
+++ b/Civi/Adyen/Notification/Report.php
@@ -220,14 +220,20 @@ class Report {
 
   private function processReport() {
     $success = TRUE;
+    $notification = AdyenNotification::get()
+      ->addWhere('id', '=', $this->id)
+      ->execute()
+      ->first();
+
     $reportLines = AdyenReportLine::get()
       ->addWhere('adyen_notification_id', '=', $this->id)
       ->addWhere('status_id', '=', 1)
       ->addOrderBy('line_date', 'ASC')
       ->addOrderBy('line_number', 'ASC')
       ->execute();
+
     foreach ($reportLines as $reportLine) {
-      $reportProcessor = new Processor\SettlementDetail($reportLine, $this->notification);
+      $reportProcessor = new Processor\SettlementDetail($reportLine, $notification);
       if (!$reportProcessor->process()) {
         $success = FALSE;
       }

--- a/tests/phpunit/Civi/Adyen/Report/Processor/SettlementDetailTest.php
+++ b/tests/phpunit/Civi/Adyen/Report/Processor/SettlementDetailTest.php
@@ -135,7 +135,7 @@ class Civi_Adyen_Report_Processor_SettlementDetailTest extends \PHPUnit\Framewor
       $this->createReportLine(1, []),
       $this->report
     );
-    $reportProcessor->process();
+    $this->assertTrue($reportProcessor->process());
     $this->assertContributionDetailsMatch($contribution['id'], [
       'contribution_status_id' => 1,
       'total_amount' => 50.00,
@@ -154,7 +154,7 @@ class Civi_Adyen_Report_Processor_SettlementDetailTest extends \PHPUnit\Framewor
       ]),
       $this->report
     );
-    $reportProcessor->process();
+    $this->assertTrue($reportProcessor->process());
     $this->assertContributionDetailsMatch($contribution['id'], [
       'contribution_status_id' => 3,
       'cancel_date' => '2020-02-24 00:00:00',
@@ -171,7 +171,7 @@ class Civi_Adyen_Report_Processor_SettlementDetailTest extends \PHPUnit\Framewor
       ]),
       $this->report
     );
-    $reportProcessor->process();
+    $this->assertTrue($reportProcessor->process());
     $this->assertContributionDetailsMatch($contribution['id'], [
       'contribution_status_id' => 1,
       'total_amount' => 50.00,


### PR DESCRIPTION
This fixes an issue where `Notification\Report` expects an `AdyenNotification` entity array, but receives the original Adyen payload instead. This causes the `event_date` not to be set (as the relevant payload value is called `eventDate` instead), causing empty `cancel_date` values.